### PR TITLE
Fixing an issue in Client.prototype._ping where self is used instead of this

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -256,7 +256,7 @@ Client.prototype.prepare = function(query) {
 }
 
 Client.prototype._ping = function() {
-  self.query('DO 0', true, true);
+  this.query('DO 0', true, true);
   this._pinger = setTimeout(this._ping, this.pingInterval);
 };
 


### PR DESCRIPTION
The offending change was causing exceptions when the client was pinged, because self is undefined in the context. No reason not to use this, so changed it.
