### PR TITLE
JavaScript Number support for query results.

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -653,7 +653,7 @@ class Client : public ObjectWrap {
             new_buf[i] = buf[i];
           field_value = String::New(new_buf, vlen);
           delete new_buf;
-        } else if (IS_NUM(fields[f].type))
+        } else if (IS_NUM(fields[f].type) && fields[f].type != MYSQL_TYPE_LONGLONG)
           field_value = Number::New(atof(cur_query.row[f]));
          else
           field_value = String::New(cur_query.row[f], lengths[f]);


### PR DESCRIPTION
The results that you get back from a query that contains numbers in a field are returned as strings. This is not ideal as you must be aware of your types when you're doing your queries and must convert them later. 

Instead, I convert any MySQL numbers to JS numbers in emit_row() 

src/bindings.cc:
      - converted the row result to a JS number using atof and IS_NUM MySQL macro
