### PR TITLE
Included string.h as strdup requires string.h

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <mysql.h>
+#include <string.h>
 
 using namespace node;
 using namespace v8;


### PR DESCRIPTION
This doesn't seem to be an issue on Mac OSX, but when I build node-MariaSQL on CentOS 6.4 x86_64, there are compile issues. 

I have fixed this issue by including string.h 

references:
http://linux.die.net/man/3/strdup
http://pubs.opengroup.org/onlinepubs/009695399/functions/strdup.html
