### PR TITLE
Fixing a bug in Client.prototype.prepare that can cause the wrong query to run.

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -253,8 +253,13 @@ Client.prototype.prepare = function(query) {
           ret += parts[j];
         return ret;
       };
-      if (this.queryCache.length === MAX_CACHE_SIZE)
+      if (this.queryCache.length === MAX_CACHE_SIZE) {
         delete this.queryCache.keys[this.queryCache.shift().orig];
+        var queries = Object.keys(this.queryCache.keys);
+        for (var idx = 0; idx < queries.length; ++idx) {
+          --this.queryCache.keys[queries[idx]];
+        }
+      }
       fn.orig = query;
       this.queryCache.keys[query] = this.queryCache.push(fn) - 1;
       return fn;


### PR DESCRIPTION
When doing more than MAX_CACHE_SIZE different queries with the same client, Client.prototype.prepare removes the oldest query from its cache, but it does not update the indices for the other cached queries. What then happens is that next time you try to run a query that's in the cache, it will run a completely different query instead.

lib/Client.js:
- Properly decrement indices of cached queries in queryCache.keys when removing an old query from the cache.
