### PR TITLE
Use UTF8 when escaping.

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -701,7 +701,7 @@ class Client : public ObjectWrap {
           String::New("You must supply a string"))
         );
       }
-      String::Value arg_v(args[0]);
+      String::Utf8Value arg_v(args[0]);
       unsigned long arg_len = arg_v.length();
       char *result = (char*) malloc(arg_len * 2 + 1);
       unsigned long result_len = obj->escape((char*)*arg_v, arg_len, result);


### PR DESCRIPTION
Whenever I tried to escape a string on a UTF8 connection, I got garbage back. This seems to fix the problem (but I'm not that familiar with coding in C).
