### PR TITLE
Minor Improvements

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -298,7 +298,7 @@ Client.prototype._reset = function() {
     // neither abort nor end event has been fired for _curResults
     // so keep _curResults for future error handling or replay after auto-reconnect
     if (this._curResults)
-      this._queries.unshift(this._curResults)
+      this._queries.unshift(this._curResults);
   this._curResults = undefined;
 };
 
@@ -352,7 +352,7 @@ Results.prototype.abort = function(active) {
     } else if ((i = this.client._queries.indexOf(this)) > -1) {
       // remove from the queue if the query hasn't started executing yet
       this.client._queries.splice(i, 1);
-      this.emit('abort')
+      this.emit('abort');
     }
   }
   return this._aborted;


### PR DESCRIPTION
The most important change is #6c08104 so that when any connection error occurs, we have a chance to clean up all pending queries, including the ongoing one. This works because it's guaranteed that abort or end event has not been fired when such occurs.
