### PR TITLE
Added metadata option to return column type and charsets

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -124,9 +124,9 @@ function Client() {
     if (self._curResults)
       self._curResults._curQuery.emit('abort');
   });
-  this._client.on('query.row', function(res) {
+  this._client.on('query.row', function(res, metadata) {
     if (self._curResults)
-      self._curResults._curQuery.emit('row', res);
+      self._curResults._curQuery.emit('row', res, metadata);
   });
   this._client.on('query.done', function(info) {
     if (self._curResults) {


### PR DESCRIPTION
This PR adresses #39

It basically adds an option `metadata` when connection. If metadata is set to true, an additional argument will be emitted for each row, containing column type and charset. I would really like to provide some kind of test / proof that this works, but the repo doesn't seem to have any tests? One proof would be that I have used the changes to implement mariadb support in sequelize/sequelize#948, and all tests pass (including tests that BLOBs, Dates, ints etc. are returned as their proper js data types)
