### PR TITLE
Fixed a memory leak for when we're destroying the client.

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -187,7 +187,6 @@ Client.prototype.end = function() {
 };
 
 Client.prototype.destroy = function() {
-  var self = this;
   if (this.connected)
     this._client.end();
 };


### PR DESCRIPTION
We kept around event emitters that kept a reference to the client. We now call removeAllListeners on destroy.

We are pooling/destroying connections on our live servers, in about 1 day, this leak accumulated about 1-2g of RAM (I believe, since the majority of the memory was in Global handles). Looking at the containment/dominator view in a heap snapshot, we had thousands of mariasql connection laying around. After investigating the retain tree, it showed that we had a series of event listeners that were retaining "self", which is a variable in Client.js that is closed around in an event.

I've done removeAllListeners inside of a setImmediate so we still send out our 'end' event to listeners that care.
