### PR TITLE
Make connect() and destroy() safe to call multiple times

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -36,7 +36,10 @@ function Client() {
   this.threadId = undefined;
   this.connected = false;
   this.connecting = false;
+  this.destroyed = false;
   this.pingInterval = 60000;
+  this._connecting = false;
+  this._destroying = false;
   this._keepQueries = undefined;
   this._pinger = undefined;
   this._queryCache = undefined;
@@ -156,11 +159,14 @@ Client.prototype.isMariaDB = function() {
 };
 
 Client.prototype.connect = function(cfg) {
-  if (this.connected || this.connecting || this.destroyed)
+  if (this.connected || this.connecting || this.destroyed || this._connecting)
     return;
 
   var self = this;
   var ncache = 30, queryCache;
+
+  cfg = cfg || {};
+
   if (typeof cfg.queryCache === 'number')
     ncache = cfg.queryCache;
   else if (typeof cfg.queryCache === 'object')
@@ -172,28 +178,43 @@ Client.prototype.connect = function(cfg) {
   this._queryCache = queryCache;
 
   this._keepQueries = cfg.keepQueries;
-  this._reusableAfterClose = cfg.reusableAfterClose
+  this._reusableAfterClose = cfg.reusableAfterClose;
+
+  this._connecting = true;
 
   process.nextTick(function() {
     if (!isIP(cfg.host)) {
       lookup(cfg.host, function(err, address, family) {
-        if (err)
-          return self.emit('error', err);
+        self._connecting = false;
+        if (err) {
+          self.emit('error', err);
+          // consistent as close event followed by conn.error
+          return self.emit('close', true);
+        }
         cfg = clone(cfg);
         cfg.host = address;
         if (cfg.pingInterval)
           self.pingInterval = cfg.pingInterval * 1000;
-        if (!self.destroyed) {
+        if (!self.destroyed && !self.connecting && !self.connected) {
           self.connecting = true;
           self._client.connect(cfg);
+        } else if (self.destroyed) {
+          // the only scenario is destroy() before DNS resolution success
+          // emit 'close' for consistency: as long as connect() called, a 'close' event will eventually fire
+          self.emit('close');
         }
       });
     } else {
+      self._connecting = false;
       if (cfg.pingInterval)
         self.pingInterval = cfg.pingInterval * 1000;
-      if (!self.destroyed) {
+      if (!self.destroyed && !self.connecting && !self.connected) {
         self.connecting = true;
         self._client.connect(cfg);
+      } else if (self.destroyed) {
+        // the only scenario is connect() followed by a destroy()
+        // emit 'close' for consistency: as long as connect() called, a 'close' event will eventually fire
+        self.emit('close');
       }
     }
   });
@@ -211,7 +232,10 @@ Client.prototype.end = function() {
 Client.prototype.destroy = function() {
   if (this.connected || this.connecting) {
     this._reusableAfterClose = false;
-    this._client.end();
+    if (!this._destroying) {
+      this._destroying = true;
+      this._client.end();
+    }
   } else {
     this.destroyed = true;
     this._client.removeAllListeners();


### PR DESCRIPTION
 and 'close' event consistently fired as long as connect() successfully called
