### PR TITLE
Fix header search path for iojs 3.0 compatibility

### DIFF
--- a/deps/libmariadbclient/extra/yassl/yassl.gyp
+++ b/deps/libmariadbclient/extra/yassl/yassl.gyp
@@ -19,7 +19,7 @@
         'src/yassl_imp.cpp',
         'src/yassl_int.cpp',
       ],
-      'include_dirs': [
+      'include_dirs+': [
         '.',
         'include',
         'taocrypt/include',


### PR DESCRIPTION
The iojs 3.0 tarballs which node-gyp downloads now include openssl
headers which are added to the start of the search path. We need to
ensure that yassl does not attempt to build against them instead
of its own bundled versions so we inject our search path at the
start of the list instead of appending it.