### PR TITLE
remove reference to this._handle to prevent memory leaks

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -31,18 +31,7 @@ function Client(config) {
 
   EventEmitter.call(this);
 
-  this._handle = new binding({
-    context: this,
-    config: config,
-    onconnect: this._onconnect,
-    onerror: this._onerror,
-    onidle: this._onidle,
-    onresultinfo: this._onresultinfo,
-    onrow: this._onrow,
-    onresultend: this._onresultend,
-    onping: this._onping,
-    onclose: this._onclose,
-  });
+  this._handle = null;
 
   if (typeof config === 'object' && config !== null)
     this._config = config;
@@ -95,11 +84,31 @@ function Client(config) {
 }
 inherits(Client, EventEmitter);
 
+Client.prototype.initHandle = function() {
+  if (this._handle !== null) return;
+  this._handle = new binding({
+    context: this,
+    config: config,
+    onconnect: this._onconnect,
+    onerror: this._onerror,
+    onidle: this._onidle,
+    onresultinfo: this._onresultinfo,
+    onrow: this._onrow,
+    onresultend: this._onresultend,
+    onping: this._onping,
+    onclose: this._onclose,
+  });
+
+  return;
+}
+
 Client.prototype.connect = function(config, cb) {
   if (typeof config === 'function') {
     cb = config;
     config = undefined;
   }
+
+  this.initHandle();
 
   if (this.connecting) {
     if (typeof cb === 'function')
@@ -265,18 +274,22 @@ Client.prototype.abort = function(killConn, cb) {
 };
 
 Client.prototype.isMariaDB = function() {
+  initHandle();
   return this._handle.isMariaDB();
 };
 
 Client.prototype.lastInsertId = function() {
+  initHandle();
   return this._handle.lastInsertId();
 };
 
 Client.prototype.escape = function(str) {
+  initHandle();
   return this._handle.escape(str);
 };
 
 Client.prototype.serverVersion = function() {
+  initHandle();
   return this._handle.serverVersion();
 };
 
@@ -565,6 +578,7 @@ Client.prototype._onclose = function(err) {
     cleanupReqs([this._queue.shift()], err);
   }
   this._req = undefined;
+  this._handle = null;
   if (!err)
     this.emit('end');
   this.emit('close');
@@ -594,6 +608,7 @@ Client.prototype._processQueue = function(ignoreConnected) {
     if (this.closing && !this._handleClosing) {
       this._handleClosing = true;
       this._handle.close();
+      this._handle = null;
     } else if (!this.closing)
       this._ping();
   }

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -274,22 +274,22 @@ Client.prototype.abort = function(killConn, cb) {
 };
 
 Client.prototype.isMariaDB = function() {
-  initHandle();
+  this.initHandle();
   return this._handle.isMariaDB();
 };
 
 Client.prototype.lastInsertId = function() {
-  initHandle();
+  this.initHandle();
   return this._handle.lastInsertId();
 };
 
 Client.prototype.escape = function(str) {
-  initHandle();
+  this.initHandle();
   return this._handle.escape(str);
 };
 
 Client.prototype.serverVersion = function() {
-  initHandle();
+  this.initHandle();
   return this._handle.serverVersion();
 };
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -88,7 +88,7 @@ Client.prototype.initHandle = function() {
   if (this._handle !== null) return;
   this._handle = new binding({
     context: this,
-    config: config,
+    config: this.config,
     onconnect: this._onconnect,
     onerror: this._onerror,
     onidle: this._onidle,

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -578,7 +578,6 @@ Client.prototype._onclose = function(err) {
     cleanupReqs([this._queue.shift()], err);
   }
   this._req = undefined;
-  this._handle = null;
   if (!err)
     this.emit('end');
   this.emit('close');

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -88,9 +88,9 @@ Client.prototype._initHandle = function() {
   if (this._handle !== null) {
     return;
   }
-  this._handle = new binding({
+  return this._handle = new binding({
     context: this,
-    config: this.config,
+    config: this._config,
     onconnect: this._onconnect,
     onerror: this._onerror,
     onidle: this._onidle,
@@ -100,8 +100,6 @@ Client.prototype._initHandle = function() {
     onping: this._onping,
     onclose: this._onclose,
   });
-
-  return;
 }
 
 Client.prototype.connect = function(config, cb) {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -88,7 +88,7 @@ Client.prototype._initHandle = function() {
   if (this._handle !== null) {
     return;
   }
-  return this._handle = new binding({
+  this._handle = new binding({
     context: this,
     config: this._config,
     onconnect: this._onconnect,

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -84,8 +84,10 @@ function Client(config) {
 }
 inherits(Client, EventEmitter);
 
-Client.prototype.initHandle = function() {
-  if (this._handle !== null) return;
+Client.prototype._initHandle = function() {
+  if (this._handle !== null) {
+    return;
+  }
   this._handle = new binding({
     context: this,
     config: this.config,
@@ -108,7 +110,7 @@ Client.prototype.connect = function(config, cb) {
     config = undefined;
   }
 
-  this.initHandle();
+  this._initHandle();
 
   if (this.connecting) {
     if (typeof cb === 'function')
@@ -274,22 +276,22 @@ Client.prototype.abort = function(killConn, cb) {
 };
 
 Client.prototype.isMariaDB = function() {
-  this.initHandle();
+  this._initHandle();
   return this._handle.isMariaDB();
 };
 
 Client.prototype.lastInsertId = function() {
-  this.initHandle();
+  this._initHandle();
   return this._handle.lastInsertId();
 };
 
 Client.prototype.escape = function(str) {
-  this.initHandle();
+  this._initHandle();
   return this._handle.escape(str);
 };
 
 Client.prototype.serverVersion = function() {
-  this.initHandle();
+  this._initHandle();
   return this._handle.serverVersion();
 };
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -223,6 +223,7 @@ Client.prototype.close = function(force) {
     if (force || (this._req === undefined && this._queue.length === 0)) {
       this._handleClosing = true;
       this._handle.close();
+      this._handle = null;
     }
   }
 };


### PR DESCRIPTION
removing reference to handle on close to prevent memory leaks.

to provide background i am using mariasql with generic-pool and our memory graphs suggests that there is a memory leak. and i have ran the code locally to confirm that removing the reference to handle will allow the object to be garbage collected. 