### PR TITLE
possible fix for prevent segfault on v8

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -232,7 +232,6 @@ Client.prototype.close = function(force) {
     if (force || (this._req === undefined && this._queue.length === 0)) {
       this._handleClosing = true;
       this._handle.close();
-      this._handle = null;
     }
   }
 };
@@ -581,6 +580,7 @@ Client.prototype._onclose = function(err) {
   if (!err)
     this.emit('end');
   this.emit('close');
+  this._handle = null;
 };
 
 Client.prototype._processQueue = function(ignoreConnected) {
@@ -607,7 +607,6 @@ Client.prototype._processQueue = function(ignoreConnected) {
     if (this.closing && !this._handleClosing) {
       this._handleClosing = true;
       this._handle.close();
-      this._handle = null;
     } else if (!this.closing)
       this._ping();
   }

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -31,18 +31,7 @@ function Client(config) {
 
   EventEmitter.call(this);
 
-  this._handle = new binding({
-    context: this,
-    config: config,
-    onconnect: this._onconnect,
-    onerror: this._onerror,
-    onidle: this._onidle,
-    onresultinfo: this._onresultinfo,
-    onrow: this._onrow,
-    onresultend: this._onresultend,
-    onping: this._onping,
-    onclose: this._onclose,
-  });
+  this._handle = null;
 
   if (typeof config === 'object' && config !== null)
     this._config = config;
@@ -95,11 +84,31 @@ function Client(config) {
 }
 inherits(Client, EventEmitter);
 
+Client.prototype.initHandle = function() {
+  if (this._handle !== null) return;
+  this._handle = new binding({
+    context: this,
+    config: config,
+    onconnect: this._onconnect,
+    onerror: this._onerror,
+    onidle: this._onidle,
+    onresultinfo: this._onresultinfo,
+    onrow: this._onrow,
+    onresultend: this._onresultend,
+    onping: this._onping,
+    onclose: this._onclose,
+  });
+
+  return;
+}
+
 Client.prototype.connect = function(config, cb) {
   if (typeof config === 'function') {
     cb = config;
     config = undefined;
   }
+
+  this.initHandle();
 
   if (this.connecting) {
     if (typeof cb === 'function')
@@ -265,18 +274,22 @@ Client.prototype.abort = function(killConn, cb) {
 };
 
 Client.prototype.isMariaDB = function() {
+  initHandle();
   return this._handle.isMariaDB();
 };
 
 Client.prototype.lastInsertId = function() {
+  initHandle();
   return this._handle.lastInsertId();
 };
 
 Client.prototype.escape = function(str) {
+  initHandle();
   return this._handle.escape(str);
 };
 
 Client.prototype.serverVersion = function() {
+  initHandle();
   return this._handle.serverVersion();
 };
 
@@ -565,6 +578,7 @@ Client.prototype._onclose = function(err) {
     cleanupReqs([this._queue.shift()], err);
   }
   this._req = undefined;
+  this._handle = null;
   if (!err)
     this.emit('end');
   this.emit('close');
@@ -594,6 +608,7 @@ Client.prototype._processQueue = function(ignoreConnected) {
     if (this.closing && !this._handleClosing) {
       this._handleClosing = true;
       this._handle.close();
+      this._handle = null;
     } else if (!this.closing)
       this._ping();
   }

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -274,22 +274,22 @@ Client.prototype.abort = function(killConn, cb) {
 };
 
 Client.prototype.isMariaDB = function() {
-  initHandle();
+  this.initHandle();
   return this._handle.isMariaDB();
 };
 
 Client.prototype.lastInsertId = function() {
-  initHandle();
+  this.initHandle();
   return this._handle.lastInsertId();
 };
 
 Client.prototype.escape = function(str) {
-  initHandle();
+  this.initHandle();
   return this._handle.escape(str);
 };
 
 Client.prototype.serverVersion = function() {
-  initHandle();
+  this.initHandle();
   return this._handle.serverVersion();
 };
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -88,7 +88,7 @@ Client.prototype.initHandle = function() {
   if (this._handle !== null) return;
   this._handle = new binding({
     context: this,
-    config: config,
+    config: this.config,
     onconnect: this._onconnect,
     onerror: this._onerror,
     onidle: this._onidle,

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -581,6 +581,15 @@ Client.prototype._onclose = function(err) {
   if (!err)
     this.emit('end');
   this.emit('close');
+  /**
+   there was a serious memory leak issue when using Client in a pool setup. 
+   if a client was used once and then close()ed the _handle was causing Client to never be garbage collection correctly. 
+   so the bindings was leaking around xMB everytime. 
+   the details around this is documented here 
+   https://github.com/mscdex/node-mariasql/pull/130 
+   and
+   https://github.com/mscdex/node-mariasql/pull/133
+  **/
   process.nextTick(this._clearHandle);
 };
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -578,7 +578,6 @@ Client.prototype._onclose = function(err) {
     cleanupReqs([this._queue.shift()], err);
   }
   this._req = undefined;
-  this._handle = null;
   if (!err)
     this.emit('end');
   this.emit('close');

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -581,8 +581,12 @@ Client.prototype._onclose = function(err) {
   if (!err)
     this.emit('end');
   this.emit('close');
-  this._handle = null;
+  process.nextTick(this._clearHandle);
 };
+
+Client.prototype._clearHandle = function () {
+  return this._handle = null;
+}
 
 Client.prototype._processQueue = function(ignoreConnected) {
   var connected = this.connected;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -88,9 +88,9 @@ Client.prototype._initHandle = function() {
   if (this._handle !== null) {
     return;
   }
-  this._handle = new binding({
+  return this._handle = new binding({
     context: this,
-    config: this.config,
+    config: this._config,
     onconnect: this._onconnect,
     onerror: this._onerror,
     onidle: this._onidle,
@@ -100,8 +100,6 @@ Client.prototype._initHandle = function() {
     onping: this._onping,
     onclose: this._onclose,
   });
-
-  return;
 }
 
 Client.prototype.connect = function(config, cb) {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -136,6 +136,7 @@ Client.prototype.connect = function(config, cb) {
   setImmediate(function() {
     // Doing a manual resolve prevents libmariadbclient from doing a blocking
     // DNS resolve
+    self._initHandle();
     if (!isIP(cfg.host)) {
       lookup(cfg.host, function(err, address, family) {
         if (err) {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -88,7 +88,7 @@ Client.prototype._initHandle = function() {
   if (this._handle !== null) {
     return;
   }
-  return this._handle = new binding({
+  this._handle = new binding({
     context: this,
     config: this._config,
     onconnect: this._onconnect,

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -84,8 +84,10 @@ function Client(config) {
 }
 inherits(Client, EventEmitter);
 
-Client.prototype.initHandle = function() {
-  if (this._handle !== null) return;
+Client.prototype._initHandle = function() {
+  if (this._handle !== null) {
+    return;
+  }
   this._handle = new binding({
     context: this,
     config: this.config,
@@ -108,7 +110,7 @@ Client.prototype.connect = function(config, cb) {
     config = undefined;
   }
 
-  this.initHandle();
+  this._initHandle();
 
   if (this.connecting) {
     if (typeof cb === 'function')
@@ -274,22 +276,22 @@ Client.prototype.abort = function(killConn, cb) {
 };
 
 Client.prototype.isMariaDB = function() {
-  this.initHandle();
+  this._initHandle();
   return this._handle.isMariaDB();
 };
 
 Client.prototype.lastInsertId = function() {
-  this.initHandle();
+  this._initHandle();
   return this._handle.lastInsertId();
 };
 
 Client.prototype.escape = function(str) {
-  this.initHandle();
+  this._initHandle();
   return this._handle.escape(str);
 };
 
 Client.prototype.serverVersion = function() {
-  this.initHandle();
+  this._initHandle();
   return this._handle.serverVersion();
 };
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -223,6 +223,7 @@ Client.prototype.close = function(force) {
     if (force || (this._req === undefined && this._queue.length === 0)) {
       this._handleClosing = true;
       this._handle.close();
+      this._handle = null;
     }
   }
 };

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -957,7 +957,7 @@ class Client : public Nan::ObjectWrap {
       Client* obj = (Client*)handle->data;
       DBG_LOG("[%lu] cb_close() state=%s\n",
               obj->threadId, state_strings[obj->state]);
-                                                                                          
+
       obj->onclose->Call(Nan::New<Object>(obj->context), 0, nullptr);
     }
 

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -955,7 +955,6 @@ class Client : public Nan::ObjectWrap {
       Nan::HandleScope scope;
 
       Client* obj = (Client*)handle->data;
-      
       DBG_LOG("[%lu] cb_close() state=%s\n",
               obj->threadId, state_strings[obj->state]);
               

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -957,7 +957,7 @@ class Client : public Nan::ObjectWrap {
       Client* obj = (Client*)handle->data;
       DBG_LOG("[%lu] cb_close() state=%s\n",
               obj->threadId, state_strings[obj->state]);
-              
+                                                                                          
       obj->onclose->Call(Nan::New<Object>(obj->context), 0, nullptr);
     }
 

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -957,6 +957,11 @@ class Client : public Nan::ObjectWrap {
       Client* obj = (Client*)handle->data;
       DBG_LOG("[%lu] cb_close() state=%s\n",
               obj->threadId, state_strings[obj->state]);
+              
+      if (NULL == obj->state) {
+        DBG_LOG("[%lu] cb_close() bindings have been garbage collected returning to avoid SIGSEGV on v8\n", obj->threadId);
+        return;
+      }                  
 
       obj->onclose->Call(Nan::New<Object>(obj->context), 0, nullptr);
     }

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -955,14 +955,10 @@ class Client : public Nan::ObjectWrap {
       Nan::HandleScope scope;
 
       Client* obj = (Client*)handle->data;
+      
       DBG_LOG("[%lu] cb_close() state=%s\n",
               obj->threadId, state_strings[obj->state]);
               
-      if (NULL == obj->state) {
-        DBG_LOG("[%lu] cb_close() bindings have been garbage collected returning to avoid SIGSEGV on v8\n", obj->threadId);
-        return;
-      }                  
-
       obj->onclose->Call(Nan::New<Object>(obj->context), 0, nullptr);
     }
 


### PR DESCRIPTION
@mscdex Brian, i am not an expert on the topic. but with my limited knowledge and few hours of GDBing through the race condition, i am suggesting this fix to bindings.cc. this should handle any case where Client is garbage collected before the call ends on bindings and resulting a callback to a none existing JS object. 

all relevant info was added to PR #130 