### PR TITLE
use binary encoding for buffers

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -646,7 +646,7 @@ Client.prototype._ping = function() {
 
 Client.prototype._format_value = function(v) {
   if (Buffer.isBuffer(v))
-    return "X'" + Client.escape(v.toString('hex')) + "'";
+    return "X'" + v.toString('hex') + "'";
   else if (Array.isArray(v)) {
     var r = [];
     for (var i = 0, len = v.length; i < len; ++i)

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -646,7 +646,7 @@ Client.prototype._ping = function() {
 
 Client.prototype._format_value = function(v) {
   if (Buffer.isBuffer(v))
-    return "'" + Client.escape(v.toString('utf8')) + "'";
+    return "X'" + Client.escape(v.toString('hex')) + "'";
   else if (Array.isArray(v)) {
     var r = [];
     for (var i = 0, len = v.length; i < len; ++i)


### PR DESCRIPTION
Fix for https://github.com/mscdex/node-mariasql/issues/50: buffers should be passed through to MariaDB with binary encoding, not in unicode -- the code in master does not allow for transferring binary data like binary-encoded UUIDs, file contents, etc.

I'm sure this will be a discussion so consider a start of the conversation: should node-mariasql attempt to support binary columns?

Testing:
- all unit tests still pass.
- used on a local development environment of a @navahq system -- all of our mariaDB use cases and tests pass with the new code.