### PR TITLE
Modified prepare function to correctly handle ':' and '?' within quotes

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -303,7 +303,6 @@ Client.prototype.prepare = function(query) {
   var curpos = 0;
   var start = 0;
   var parts = [];
-  var wasInQuote = false;
   var inQuote = false;
   var escape = false;
   var tokens = [];
@@ -316,7 +315,6 @@ Client.prototype.prepare = function(query) {
 
   if (ppos) {
     do {
-      wasInQuote = inQuote;
       for (i = curpos, end = ppos.index; i < end; ++i) {
         chr = query.charCodeAt(i);
         if (chr === BSLASH)
@@ -342,8 +340,6 @@ Client.prototype.prepare = function(query) {
 
       if (!inQuote) {
         parts.push(query.slice(start, end));
-        if (wasInQuote)
-          tokens.push(null);
         tokens.push(ppos[0].length === 1 ? qcnt++ : ppos[1]);
         start = end + ppos[0].length;
       }

--- a/test/test.js
+++ b/test/test.js
@@ -76,6 +76,50 @@ var tests = [
                          "SELECT * FROM foo WHERE id = '123'"
                          + " AND first = 'foo' AND last = '?'"
                          + " AND middle = '?'");
+
+      fn = client.prepare("SELECT * FROM foo WHERE id = '?'"
+                         + " AND first = ? AND last = '?' AND middle = '?'");
+      assert.strictEqual(fn(['foo', 'bar', 'baz']),
+                        "SELECT * FROM foo WHERE id = '?'"
+                        + " AND first = 'foo' AND last = '?'"
+                        + " AND middle = '?'");
+
+      fn = client.prepare("SELECT 'test?value' FROM foo WHERE id = :id"
+                         + " AND first = ? AND last = '?' AND middle = '?'");
+      assert.strictEqual(fn(appendProps(['foo', 'bar', 'baz'], { id: '123' })),
+                        "SELECT 'test?value' FROM foo WHERE id = '123'"
+                        + " AND first = 'foo' AND last = '?'"
+                        + " AND middle = '?'");
+      fn = client.prepare("SELECT ? FROM foo WHERE id = :id"
+                        + " AND first = ? AND last = '?' AND middle = '?'");
+      assert.strictEqual(fn(appendProps(['foo', 'bar', 'baz'], { id: '123' })),
+                       "SELECT 'foo' FROM foo WHERE id = '123'"
+                       + " AND first = 'bar' AND last = '?'"
+                       + " AND middle = '?'");
+      fn = client.prepare("SELECT ?, '?' FROM foo WHERE id = :id"
+                         + " AND first = ? AND last = '?' AND middle = '?'");
+      assert.strictEqual(fn(appendProps(['foo', 'bar', 'baz'], { id: '123' })),
+                        "SELECT 'foo', '?' FROM foo WHERE id = '123'"
+                        + " AND first = 'bar' AND last = '?'"
+                        + " AND middle = '?'");
+      fn = client.prepare("SELECT :id FROM foo WHERE id = :id"
+                         + " AND first = ? AND last = '?' AND middle = '?'");
+      assert.strictEqual(fn(appendProps(['foo', 'bar', 'baz'], { id: '123' })),
+                        "SELECT '123' FROM foo WHERE id = '123'"
+                        + " AND first = 'foo' AND last = '?'"
+                        + " AND middle = '?'");
+      fn = client.prepare("SELECT ':id' FROM foo WHERE id = :id"
+                       + " AND first = ? AND last = '?' AND middle = '?'");
+      assert.strictEqual(fn(appendProps(['foo', 'bar', 'baz'], { id: '123' })),
+                      "SELECT ':id' FROM foo WHERE id = '123'"
+                      + " AND first = 'foo' AND last = '?'"
+                      + " AND middle = '?'");
+      fn = client.prepare("SELECT '?', ':id', ?, :id FROM foo WHERE id = :id"
+                       + " AND first = ? AND last = '?' AND middle = '?'");
+      assert.strictEqual(fn(appendProps(['foo', 'bar', 'baz'], { id: '123' })),
+                      "SELECT '?', ':id', 'foo', '123' FROM foo WHERE id = '123'"
+                      + " AND first = 'bar' AND last = '?'"
+                      + " AND middle = '?'");
       next();
     }
   },
@@ -1035,7 +1079,7 @@ function makeFooTable(client, colDefs, tableOpts) {
       opts.push(format('%s=%s', key, tableOpts[key]));
     });
     tableOpts = opts.join(' ');
-  } else 
+  } else
     tableOpts = '';
 
   client.query('CREATE DATABASE IF NOT EXISTS `foo`', NOOP);
@@ -1045,7 +1089,7 @@ function makeFooTable(client, colDefs, tableOpts) {
                  cols.join(', '),
                  tableOpts);
   client.query(query, NOOP);
-  
+
 }
 
 function next() {


### PR DESCRIPTION
Fix for issue [#129](https://github.com/mscdex/node-mariasql/issues/129).

Parsing of query has been changed to so that `:` or `?` within quotes at the start of a statement are handled correctly. 