### PR TITLE
Fixed quotation of numbers inside prepared statements

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -652,6 +652,8 @@ Client.prototype._format_value = function(v) {
     for (var i = 0, len = v.length; i < len; ++i)
       r.push(this._format_value(v[i]));
     return r.join(',');
+  } else if (Number.isInteger(v)) {
+    return v;
   } else if (v !== null && v !== undefined)
     return "'" + Client.escape(v + '') + "'";
 


### PR DESCRIPTION
Addressing issue https://github.com/mscdex/node-mariasql/issues/94

Checks if item is an integer, and if so returns it without adding
quotations.

Fixes OFFSET, LIMIT and other keywords that take integers in prepared
statements.