### PR TITLE
Remove dependency on alloca.h to build on BSD (v2)

### DIFF
--- a/deps/libmariadbclient/include/mysql/service_encryption.h
+++ b/deps/libmariadbclient/include/mysql/service_encryption.h
@@ -34,8 +34,12 @@ extern "C" {
 #ifndef __cplusplus
 #define inline __inline
 #endif
+#elif defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
+#include <stdlib.h>
 #else
+#ifndef __FreeBSD__
 #include <alloca.h>
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
Code changes from MariaDB 10.1.20's mysql/service_encryption.h