### PR TITLE
Client: support 'OR" operator between 'pingInactive' and 'pingWaitRes'

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -631,11 +631,18 @@ function pingCb(self) {
   self._handle.ping();
 }
 Client.prototype._ping = function() {
-  if (this._tmrInactive === undefined
+  if ((this._tmrInactive === undefined
       && typeof this._config.pingInactive === 'number'
+      && this._config.pingInactive > 0)
+      || (this._tmrInactive === undefined
       && typeof this._config.pingWaitRes === 'number'
-      && this._config.pingInactive > 0
-      && this._config.pingWaitRes > 0) {
+      && this._config.pingWaitRes > 0)) {
+    if (this._config.pingInactive === undefined) {
+      this._config.pingInactive = 60000;
+    }
+    if (this._config.pingWaitRes === undefined) {
+      this._config.pingWaitRes = 60000;
+    }
     this._tmrInactive = setTimeout(pingCb, this._config.pingInactive, this);
   }
 };


### PR DESCRIPTION
This commit is to fix issue https://github.com/mscdex/node-mariasql/issues/181.

According to https://github.com/mscdex/node-mariasql/blob/master/lib/Client.js#L633 ,
The protocol-level pings can be enabled by setting both 'pingInactive' and
'pingWaitRes' variablei as following:

a. 'pingInactive' to how many milliseconds to wait before sending a ping
   when no queries are pending,
b. AND 'pingWaitRes' to how many milliseconds to wait for a ping response
   before assuming a lost/dead connection.

For example, If you want to check a connection state per 60 seconds, we have
to define both 'pingInactive' and pingWaitRes. It means that the "MySQL server
has gone away" issue will be always generated in case that we declare the
timeout with one between 'pingInactive' and 'pingWaitRes'.

Let's support an optional conditional operator instead of "AND" operation conditions.
If user does not declared a default timeout, it will be 60 seconds by default.

* Example source code:
[foo.js]
pingInactive: 60000,

* Before applying this patch:
events.js:160
      throw er; // Unhandled 'error' event
      ^
Error: MySQL server has gone away
    at Error (native)

* How to monitor a sleep time of database on MariaDB server:
$ sudo apt-get install mytop [enter]
$ mytop -u root -p**** ourjs [enter]
MySQL on localhost (10.0.29)   load 0.32 0.30 0.26 2/580 9391 up 0+14:33:20 [07:47:10]
 Queries: 1.7k     qps:    0 Slow:     0.0         Se/In/Up/De(%):    02/00/00/00
 Sorts:      0 qps now:    1 Slow qps: 0.0  Threads:    3 (   1/   2) 00/00/00/00
 Key Efficiency: 100.0%  Bps in/out:   0.9/127.1   Now in/out:  21.3/ 2.9k

       Id      User         Host/IP         DB       Time    Cmd    State Query
       --      ----         -------         --       ----    ---    ----- ----------
      754       ourjs localhost:34766        test         38  Sleep
$ cat /proc/754/stat
$ cat /proc/754/status

* How to change a default timeout of Mariadb server:
$ sudo vi /etc/mysql/mariadb.conf.d/50-server.cnf
[mysqld]
wait_timeout = 120 (default value is 28800secs)
interactive_timeout = 120 (default value is 28800secs)

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>

\CC: @myungjoo