### PR TITLE
Solved: Build error with Node.js 8.0.0 and/or npm 5.0.0 on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+build

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ env:
   - TRAVIS_NODE_VERSION="0.12"
   - TRAVIS_NODE_VERSION="4"
   - TRAVIS_NODE_VERSION="5"
+  - TRAVIS_NODE_VERSION="6"
+  - TRAVIS_NODE_VERSION="7"
+  - TRAVIS_NODE_VERSION="8"
 install:
   - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew update > /dev/null && brew install mariadb && mysql.server start; fi
   - "rm -rf ~/.nvm && mkdir -p ~/.nvm && curl -sL `curl -sI https://github.com/creationix/nvm/releases/latest|sed -En 's/^Location: (.+)\\/releases\\/tag\\/(.+)/\\1\\/tarball\\/\\2/p'|tr -d '\r\n'`|tar zx --strip=1 -C ~/.nvm && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,9 @@ environment:
     - nodejs_version: "0.12"
     - nodejs_version: "4"
     - nodejs_version: "5"
+    - nodejs_version: "6"
+    - nodejs_version: "7"
+    - nodejs_version: "8"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/binding.gyp
+++ b/binding.gyp
@@ -11,6 +11,9 @@
         "<!(node -e \"require('nan')\")"
       ],
       'cflags': [ '-O3', '-std=c++0x' ],
+      "cflags_cc!": [
+        "-fno-rtti"
+      ],
       'conditions': [
         [ 'OS=="win"', {
             # Re-enable warnings that were disabled for libmariadbclient

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,17 @@
+{
+  "name": "mariasql",
+  "version": "0.2.6",
+  "lockfileVersion": 1,
+  "dependencies": {
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+    },
+    "nan": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
+      "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
-{ "name": "mariasql",
+{
+  "name": "mariasql",
   "version": "0.2.6",
   "author": "Brian White <mscdex@mscdex.net>",
   "description": "A node.js binding to MariaDB's non-blocking (MySQL-compatible) client library",
   "main": "./lib/Client",
-  "engines": { "node": ">=0.10.0" },
+  "engines": {
+    "node": ">=0.10.0"
+  },
   "dependencies": {
     "lru-cache": "^2.7.0",
     "nan": "^2.0.9"
@@ -11,7 +14,22 @@
   "scripts": {
     "test": "node test/test.js"
   },
-  "keywords": [ "mysql", "sql", "client", "mariadb", "async", "nonblocking" ],
-  "licenses": [ { "type": "MIT", "url": "http://github.com/mscdex/node-mariasql/raw/master/LICENSE" } ],
-  "repository" : { "type": "git", "url": "http://github.com/mscdex/node-mariasql.git" }
+  "keywords": [
+    "mysql",
+    "sql",
+    "client",
+    "mariadb",
+    "async",
+    "nonblocking"
+  ],
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://github.com/mscdex/node-mariasql/raw/master/LICENSE"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/mscdex/node-mariasql.git"
+  }
 }


### PR DESCRIPTION
I've just updated our build process to Node.js 8.0.0 and/or npm 5.0.0 (also tried 5.0.1).

When I executed the build process after updating, an error occurred.

Here's the error log:
```
In file included from ../src/binding.cc:54:
/usr/lib/gcc/x86_64-redhat-linux/4.4.7/../../../../include/c++/4.4.7/bits/shared_ptr.h:146:24: error: cannot use typeid with -fno-rtti
      { return __ti == typeid(_Deleter) ? &_M_del._M_del : 0; }
                       ^
/usr/lib/gcc/x86_64-redhat-linux/4.4.7/../../../../include/c++/4.4.7/bits/shared_ptr.h:204:24: error: cannot use typeid with -fno-rtti
        return __ti == typeid(_Sp_make_shared_tag)
                       ^
/usr/lib/gcc/x86_64-redhat-linux/4.4.7/../../../../include/c++/4.4.7/bits/shared_ptr.h:861:50: error: cannot use typeid with -fno-rtti
          void* __p = _M_refcount._M_get_deleter(typeid(__tag));
                                                 ^
/usr/lib/gcc/x86_64-redhat-linux/4.4.7/../../../../include/c++/4.4.7/bits/shared_ptr.h:1005:52: error: cannot use typeid with -fno-rtti
    { return static_cast<_Del*>(__p._M_get_deleter(typeid(_Del))); }
                                                   ^
gyp ERR! build error
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/usr/local/nvm/versions/node/v8.0.0/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:285:23)
gyp ERR! stack     at emitTwo (events.js:125:13)
gyp ERR! stack     at ChildProcess.emit (events.js:213:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:197:12)
gyp ERR! System Linux 2.6.32-642.13.1.el6.x86_64
gyp ERR! command "/usr/local/nvm/versions/node/v8.0.0/bin/node" "/usr/local/nvm/versions/node/v8.0.0/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /tmp/yoshida/node-test/node_modules/mariasql
gyp ERR! node -v v8.0.0
gyp ERR! node-gyp -v v3.6.1
gyp ERR! not ok
npm WARN test@1.0.0 No description
npm WARN test@1.0.0 No repository field.
 
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! mariasql@0.2.6 install: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the mariasql@0.2.6 install script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```

<details>
  <summary>All build log</summary>

```
[vagrant@i3-dev node-mariasql]$ npm install

> mariasql@0.2.6 install /vagrant/projects/node-mariasql
> node-gyp rebuild

gyp WARN download NVM_NODEJS_ORG_MIRROR is deprecated and will be removed in node-gyp v4, please use NODEJS_ORG_MIRROR
gyp WARN download NVM_NODEJS_ORG_MIRROR is deprecated and will be removed in node-gyp v4, please use NODEJS_ORG_MIRROR
gyp WARN download NVM_NODEJS_ORG_MIRROR is deprecated and will be removed in node-gyp v4, please use NODEJS_ORG_MIRROR
make: ディレクトリ `/vagrant/projects/node-mariasql/build' に入ります
  CXX(target) Release/obj.target/taocrypt/deps/libmariadbclient/extra/yassl/taocrypt/src/aes.o
  CXX(target) Release/obj.target/taocrypt/deps/libmariadbclient/extra/yassl/taocrypt/src/aestables.o
  CXX(target) Release/obj.target/taocrypt/deps/libmariadbclient/extra/yassl/taocrypt/src/algebra.o
  CXX(target) Release/obj.target/taocrypt/deps/libmariadbclient/extra/yassl/taocrypt/src/arc4.o
  CXX(target) Release/obj.target/taocrypt/deps/libmariadbclient/extra/yassl/taocrypt/src/asn.o
  CXX(target) Release/obj.target/taocrypt/deps/libmariadbclient/extra/yassl/taocrypt/src/bftables.o
  CXX(target) Release/obj.target/taocrypt/deps/libmariadbclient/extra/yassl/taocrypt/src/blowfish.o
  CXX(target) Release/obj.target/taocrypt/deps/libmariadbclient/extra/yassl/taocrypt/src/coding.o
  CXX(target) Release/obj.target/taocrypt/deps/libmariadbclient/extra/yassl/taocrypt/src/des.o
../deps/libmariadbclient/extra/yassl/taocrypt/src/des.cpp:227:5: warning: 'register' storage class specifier is deprecated [-Wdeprecated-register]
    register int i,j,l;
    ^~~~~~~~~
../deps/libmariadbclient/extra/yassl/taocrypt/src/des.cpp:227:5: warning: 'register' storage class specifier is deprecated [-Wdeprecated-register]
    register int i,j,l;
    ^~~~~~~~~
../deps/libmariadbclient/extra/yassl/taocrypt/src/des.cpp:227:5: warning: 'register' storage class specifier is deprecated [-Wdeprecated-register]
    register int i,j,l;
    ^~~~~~~~~
3 warnings generated.
  CXX(target) Release/obj.target/taocrypt/deps/libmariadbclient/extra/yassl/taocrypt/src/dh.o
  CXX(target) Release/obj.target/taocrypt/deps/libmariadbclient/extra/yassl/taocrypt/src/dsa.o
  CXX(target) Release/obj.target/taocrypt/deps/libmariadbclient/extra/yassl/taocrypt/src/file.o
  CXX(target) Release/obj.target/taocrypt/deps/libmariadbclient/extra/yassl/taocrypt/src/hash.o
  CXX(target) Release/obj.target/taocrypt/deps/libmariadbclient/extra/yassl/taocrypt/src/hc128.o
  CXX(target) Release/obj.target/taocrypt/deps/libmariadbclient/extra/yassl/taocrypt/src/integer.o
  CXX(target) Release/obj.target/taocrypt/deps/libmariadbclient/extra/yassl/taocrypt/src/md2.o
  CXX(target) Release/obj.target/taocrypt/deps/libmariadbclient/extra/yassl/taocrypt/src/md4.o
  CXX(target) Release/obj.target/taocrypt/deps/libmariadbclient/extra/yassl/taocrypt/src/md5.o
  CXX(target) Release/obj.target/taocrypt/deps/libmariadbclient/extra/yassl/taocrypt/src/misc.o
  CXX(target) Release/obj.target/taocrypt/deps/libmariadbclient/extra/yassl/taocrypt/src/rabbit.o
  CXX(target) Release/obj.target/taocrypt/deps/libmariadbclient/extra/yassl/taocrypt/src/random.o
  CXX(target) Release/obj.target/taocrypt/deps/libmariadbclient/extra/yassl/taocrypt/src/ripemd.o
  CXX(target) Release/obj.target/taocrypt/deps/libmariadbclient/extra/yassl/taocrypt/src/rsa.o
  CXX(target) Release/obj.target/taocrypt/deps/libmariadbclient/extra/yassl/taocrypt/src/sha.o
  CXX(target) Release/obj.target/taocrypt/deps/libmariadbclient/extra/yassl/taocrypt/src/tftables.o
  CXX(target) Release/obj.target/taocrypt/deps/libmariadbclient/extra/yassl/taocrypt/src/twofish.o
  AR(target) Release/obj.target/deps/libmariadbclient/extra/yassl/taocrypt/taocrypt.a
  COPY Release/taocrypt.a
  CXX(target) Release/obj.target/yassl/deps/libmariadbclient/extra/yassl/src/buffer.o
  CXX(target) Release/obj.target/yassl/deps/libmariadbclient/extra/yassl/src/cert_wrapper.o
  CXX(target) Release/obj.target/yassl/deps/libmariadbclient/extra/yassl/src/crypto_wrapper.o
  CXX(target) Release/obj.target/yassl/deps/libmariadbclient/extra/yassl/src/handshake.o
  CXX(target) Release/obj.target/yassl/deps/libmariadbclient/extra/yassl/src/lock.o
  CXX(target) Release/obj.target/yassl/deps/libmariadbclient/extra/yassl/src/log.o
  CXX(target) Release/obj.target/yassl/deps/libmariadbclient/extra/yassl/src/socket_wrapper.o
../deps/libmariadbclient/extra/yassl/src/socket_wrapper.cpp:49:15: warning: unused variable 'SOCKET_EINVAL' [-Wunused-const-variable]
    const int SOCKET_EINVAL = EINVAL;
              ^
1 warning generated.
  CXX(target) Release/obj.target/yassl/deps/libmariadbclient/extra/yassl/src/ssl.o
  CXX(target) Release/obj.target/yassl/deps/libmariadbclient/extra/yassl/src/timer.o
  CXX(target) Release/obj.target/yassl/deps/libmariadbclient/extra/yassl/src/yassl_error.o
  CXX(target) Release/obj.target/yassl/deps/libmariadbclient/extra/yassl/src/yassl_imp.o
  CXX(target) Release/obj.target/yassl/deps/libmariadbclient/extra/yassl/src/yassl_int.o
../deps/libmariadbclient/extra/yassl/src/yassl_int.cpp:912:12: warning: unused variable 'handshake_order' [-Wunused-const-variable]
const char handshake_order[] = "Out of order HandShake Message!";
           ^
1 warning generated.
  AR(target) Release/obj.target/deps/libmariadbclient/extra/yassl/yassl.a
  COPY Release/yassl.a
  CC(target) Release/obj.target/clientlib/deps/libmariadbclient/sql-common/client.o
  CC(target) Release/obj.target/clientlib/deps/libmariadbclient/sql-common/client_plugin.o
  CC(target) Release/obj.target/clientlib/deps/libmariadbclient/sql-common/mysql_async.o
  CC(target) Release/obj.target/clientlib/deps/libmariadbclient/sql-common/my_time.o
  CC(target) Release/obj.target/clientlib/deps/libmariadbclient/sql-common/pack.o
  CXX(target) Release/obj.target/clientlib/deps/libmariadbclient/sql/net_serv.o
  CC(target) Release/obj.target/clientlib/deps/libmariadbclient/sql/password.o
  CC(target) Release/obj.target/clientlib/deps/libmariadbclient/libmysql/errmsg.o
  CC(target) Release/obj.target/clientlib/deps/libmariadbclient/libmysql/libmysql.o
  AR(target) Release/obj.target/deps/libmariadbclient/libmysql/clientlib.a
  COPY Release/clientlib.a
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/array.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/charset-def.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/charset.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/errors.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/hash.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/list.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/mf_arr_appstr.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/mf_dirname.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/mf_fn_ext.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/mf_format.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/mf_loadpath.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/mf_pack.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/mf_path.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/mf_qsort.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/mf_unixpath.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/mf_wcomp.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/mulalloc.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/my_access.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/my_alloc.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/my_compress.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/my_context.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/my_default.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/my_div.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/my_error.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/my_fopen.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/my_fstream.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/my_getsystime.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/my_getwd.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/my_init.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/my_lib.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/my_malloc.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/my_mess.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/my_once.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/my_open.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/my_pthread.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/my_read.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/my_seek.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/my_static.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/my_symlink.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/my_thr_init.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/my_write.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/safemalloc.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/string.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/thr_mutex.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/typelib.o
  CC(target) Release/obj.target/mysys/deps/libmariadbclient/mysys/my_sync.o
  AR(target) Release/obj.target/deps/libmariadbclient/mysys/mysys.a
  COPY Release/mysys.a
  CXX(target) Release/obj.target/mysys_ssl/deps/libmariadbclient/mysys_ssl/my_aes.o
  CXX(target) Release/obj.target/mysys_ssl/deps/libmariadbclient/mysys_ssl/my_md5.o
  CXX(target) Release/obj.target/mysys_ssl/deps/libmariadbclient/mysys_ssl/my_rnd.o
  CXX(target) Release/obj.target/mysys_ssl/deps/libmariadbclient/mysys_ssl/my_sha1.o
  CXX(target) Release/obj.target/mysys_ssl/deps/libmariadbclient/mysys_ssl/my_sha2.o
  AR(target) Release/obj.target/deps/libmariadbclient/mysys_ssl/mysys_ssl.a
  COPY Release/mysys_ssl.a
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/bchange.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/bmove_upp.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/ctype-big5.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/ctype-bin.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/ctype-cp932.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/ctype-czech.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/ctype-eucjpms.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/ctype-euc_kr.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/ctype-extra.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/ctype-gb2312.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/ctype-gbk.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/ctype-latin1.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/ctype-mb.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/ctype-simple.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/ctype-sjis.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/ctype-tis620.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/ctype-uca.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/ctype-ucs2.o
../deps/libmariadbclient/strings/ctype-ucs2.c:57:1: warning: unused function 'my_bincmp' [-Wunused-function]
my_bincmp(const uchar *s, const uchar *se,
^
1 warning generated.
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/ctype-ujis.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/ctype-utf8.o
../deps/libmariadbclient/strings/ctype-utf8.c:4894:19: warning: unused function 'bincmp' [-Wunused-function]
static inline int bincmp(const uchar *s, const uchar *se,
                  ^
../deps/libmariadbclient/strings/ctype-utf8.c:5066:1: warning: unused function 'my_tosort_utf8mb3' [-Wunused-function]
my_tosort_utf8mb3(MY_UNICASE_INFO *uni_plane, my_wc_t *wc)
^
../deps/libmariadbclient/strings/ctype-utf8.c:7279:1: warning: unused function 'bincmp_utf8mb4' [-Wunused-function]
bincmp_utf8mb4(const uchar *s, const uchar *se,
^
3 warnings generated.
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/ctype-win1250ch.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/ctype.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/dtoa.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/int2str.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/is_prefix.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/llstr.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/longlong2str.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/my_strtoll10.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/my_vsnprintf.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/str2int.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/strcend.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/strcont.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/strend.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/strfill.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/strmake.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/strmov.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/strmov_overlapp.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/strnmov.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/strxmov.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/strxnmov.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/str_alloc.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/xml.o
  CC(target) Release/obj.target/strings/deps/libmariadbclient/strings/strnlen.o
  AR(target) Release/obj.target/deps/libmariadbclient/strings/strings.a
  COPY Release/strings.a
  CC(target) Release/obj.target/vio/deps/libmariadbclient/vio/vio.o
../deps/libmariadbclient/vio/vio.c:389:3: warning: implicit declaration of function 'yaSSL_CleanUp' is invalid in C99 [-Wimplicit-function-declaration]
  yaSSL_CleanUp();
  ^
1 warning generated.
  CC(target) Release/obj.target/vio/deps/libmariadbclient/vio/viopipe.o
  CC(target) Release/obj.target/vio/deps/libmariadbclient/vio/vioshm.o
  CC(target) Release/obj.target/vio/deps/libmariadbclient/vio/viosocket.o
  CC(target) Release/obj.target/vio/deps/libmariadbclient/vio/viossl.o
  CC(target) Release/obj.target/vio/deps/libmariadbclient/vio/viosslfactories.o
  AR(target) Release/obj.target/deps/libmariadbclient/vio/vio.a
  COPY Release/vio.a
  CC(target) Release/obj.target/zlib/deps/libmariadbclient/zlib/adler32.o
  CC(target) Release/obj.target/zlib/deps/libmariadbclient/zlib/compress.o
  CC(target) Release/obj.target/zlib/deps/libmariadbclient/zlib/crc32.o
  CC(target) Release/obj.target/zlib/deps/libmariadbclient/zlib/deflate.o
  CC(target) Release/obj.target/zlib/deps/libmariadbclient/zlib/gzclose.o
  CC(target) Release/obj.target/zlib/deps/libmariadbclient/zlib/gzlib.o
  CC(target) Release/obj.target/zlib/deps/libmariadbclient/zlib/gzread.o
  CC(target) Release/obj.target/zlib/deps/libmariadbclient/zlib/gzwrite.o
  CC(target) Release/obj.target/zlib/deps/libmariadbclient/zlib/infback.o
  CC(target) Release/obj.target/zlib/deps/libmariadbclient/zlib/inffast.o
  CC(target) Release/obj.target/zlib/deps/libmariadbclient/zlib/inflate.o
  CC(target) Release/obj.target/zlib/deps/libmariadbclient/zlib/inftrees.o
  CC(target) Release/obj.target/zlib/deps/libmariadbclient/zlib/trees.o
  CC(target) Release/obj.target/zlib/deps/libmariadbclient/zlib/uncompr.o
  CC(target) Release/obj.target/zlib/deps/libmariadbclient/zlib/zutil.o
  AR(target) Release/obj.target/deps/libmariadbclient/zlib/zlib.a
  COPY Release/zlib.a
  CXX(target) Release/obj.target/sqlclient/src/binding.o
In file included from ../src/binding.cc:54:
In file included from /home/vagrant/.node-gyp/8.0.0/include/node/node.h:63:
In file included from /home/vagrant/.node-gyp/8.0.0/include/node/v8.h:21:
In file included from /usr/lib/gcc/x86_64-redhat-linux/4.4.7/../../../../include/c++/4.4.7/memory:83:
/usr/lib/gcc/x86_64-redhat-linux/4.4.7/../../../../include/c++/4.4.7/bits/shared_ptr.h:146:24: error: cannot use typeid with -fno-rtti
      { return __ti == typeid(_Deleter) ? &_M_del._M_del : 0; }
                       ^
/usr/lib/gcc/x86_64-redhat-linux/4.4.7/../../../../include/c++/4.4.7/bits/shared_ptr.h:204:24: error: cannot use typeid with -fno-rtti
        return __ti == typeid(_Sp_make_shared_tag)
                       ^
/usr/lib/gcc/x86_64-redhat-linux/4.4.7/../../../../include/c++/4.4.7/bits/shared_ptr.h:861:50: error: cannot use typeid with -fno-rtti
          void* __p = _M_refcount._M_get_deleter(typeid(__tag));
                                                 ^
/usr/lib/gcc/x86_64-redhat-linux/4.4.7/../../../../include/c++/4.4.7/bits/shared_ptr.h:1005:52: error: cannot use typeid with -fno-rtti
    { return static_cast<_Del*>(__p._M_get_deleter(typeid(_Del))); }
                                                   ^
../src/binding.cc:1240:23: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
      if (r <= 0 || r >= sizeof(u64_buf))
                    ~ ^  ~~~~~~~~~~~~~~~
../src/binding.cc:1249:25: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
        if (r <= 0 || r >= sizeof(u64_buf))
                      ~ ^  ~~~~~~~~~~~~~~~
../src/binding.cc:1256:23: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
      if (r <= 0 || r >= sizeof(u64_buf))
                    ~ ^  ~~~~~~~~~~~~~~~
../src/binding.cc:1561:23: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
      if (r <= 0 || r >= sizeof(u64_buf))
                    ~ ^  ~~~~~~~~~~~~~~~
4 warnings and 4 errors generated.
make: *** [Release/obj.target/sqlclient/src/binding.o] エラー 1
make: ディレクトリ `/vagrant/projects/node-mariasql/build' から出ます
gyp ERR! build error
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/usr/local/nvm/versions/node/v8.0.0/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:285:23)
gyp ERR! stack     at emitTwo (events.js:125:13)
gyp ERR! stack     at ChildProcess.emit (events.js:213:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:197:12)
gyp ERR! System Linux 2.6.32-642.13.1.el6.x86_64
gyp ERR! command "/usr/local/nvm/versions/node/v8.0.0/bin/node" "/usr/local/nvm/versions/node/v8.0.0/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /vagrant/projects/node-mariasql
gyp ERR! node -v v8.0.0
gyp ERR! node-gyp -v v3.6.1
gyp ERR! not ok
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! mariasql@0.2.6 install: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the mariasql@0.2.6 install script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/vagrant/.npm/_logs/2017-06-02T10_47_41_174Z-debug.log
```

</details>
</br>

Here is an error: `error: cannot use typeid with -fno-rtti`.
I found that option `-fno-rtti` is given when node-gyp is executed at Node.js 8.0.0 and/or npm 5.0.0.

By overriding node-gyp default flags (`-fno-rtti`),
I confirmed that "npm install" was successful with Node.js 8.0.0 and/or npm 5.0.0.

So, I added a setting to override this flag (`-fno-rtti`) to binding.gyp.