### PR TITLE
Added support for numeric parameters in Client#prepare()

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -648,7 +648,9 @@ Client.prototype._format_value = function(v) {
     for (var i = 0, len = v.length; i < len; ++i)
       r.push(this._format_value(v[i]));
     return r.join(',');
-  } else if (v !== null && v !== undefined)
+  } else if (Object.getPrototypeOf(v) == Number.prototype)
+    return v.toString();
+  else if (v !== null && v !== undefined)
     return "'" + Client.escape(v + '') + "'";
 
   return 'NULL';

--- a/test/test.js
+++ b/test/test.js
@@ -34,22 +34,22 @@ var tests = [
     run: function() {
       var client = new Client();
       var fn;
-      fn = client.prepare("SELECT * FROM foo WHERE id = '123'");
-      assert.strictEqual(fn({ id: 456 }),
-                         "SELECT * FROM foo WHERE id = '123'");
-      fn = client.prepare("SELECT * FROM foo WHERE id = :id");
-      assert.strictEqual(fn({ id: 123 }),
-                         "SELECT * FROM foo WHERE id = '123'");
-      assert.strictEqual(fn({ id: 456 }),
-                         "SELECT * FROM foo WHERE id = '456'");
-      fn = client.prepare("SELECT * FROM foo WHERE id = ?");
-      assert.strictEqual(fn([123]),
-                         "SELECT * FROM foo WHERE id = '123'");
-      assert.strictEqual(fn([456]),
-                         "SELECT * FROM foo WHERE id = '456'");
-      fn = client.prepare("SELECT * FROM foo WHERE id = :0 AND name = :1");
-      assert.strictEqual(fn(['123', 'baz']),
-                         "SELECT * FROM foo WHERE id = '123' AND name = 'baz'");
+      fn = client.prepare("SELECT * FROM foo WHERE id = 'ABC' LIMIT 123");
+      assert.strictEqual(fn({ id: 'DEF', limit: 456 }),
+                         "SELECT * FROM foo WHERE id = 'ABC' LIMIT 123");
+      fn = client.prepare("SELECT * FROM foo WHERE id = :id LIMIT :limit");
+      assert.strictEqual(fn({ id: 'ABC', limit: 123 }),
+                         "SELECT * FROM foo WHERE id = 'ABC' LIMIT 123");
+      assert.strictEqual(fn({ id: 'DEF', limit: 456 }),
+                         "SELECT * FROM foo WHERE id = 'DEF' LIMIT 456");
+      fn = client.prepare("SELECT * FROM foo WHERE id = ? LIMIT ?");
+      assert.strictEqual(fn(['ABC', 123]),
+                         "SELECT * FROM foo WHERE id = 'ABC' LIMIT 123");
+      assert.strictEqual(fn(['DEF', 456]),
+                         "SELECT * FROM foo WHERE id = 'DEF' LIMIT 456");
+      fn = client.prepare("SELECT * FROM foo WHERE id = :0 AND name = :1 LIMIT :2");
+      assert.strictEqual(fn(['ABC', 'baz', 123]),
+                         "SELECT * FROM foo WHERE id = 'ABC' AND name = 'baz' LIMIT 123");
 
       // Edge cases
       fn = client.prepare("SELECT * FROM foo WHERE id = :id"


### PR DESCRIPTION
`Client#prepare()` currently quotes numeric values and therefore forces the SQL engine to interpret them as strings.

However, some values, such as the one given to `LIMIT` or `OFFSET`, accept only numeric values.

For example, using MySQL 5.5:

```sql
SELECT * FROM city LIMIT '2';
```

> ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that 
corresponds to your MySQL server version for the right syntax to use near ''2'' at line 1

```sql
SELECT * FROM city LIMIT 2;
```

> [...]
> 2 rows in set (0.00 sec)

This pull request modifies `Client#prepare()` so that it leaves `Number` values alone.